### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/khasang/TrackerMonitor.png?label=ready&title=Ready)](https://waffle.io/khasang/TrackerMonitor)
 #### .net C#, ASP.net MVC 5, SignalR, Entity Framework
 ------
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/khasang/TrackerMonitor

This was requested by a real person (user thechch) on waffle.io, we're not trying to spam you.
